### PR TITLE
chore: use published light-sdks crates instead of git deps

### DIFF
--- a/account-comparison/Cargo.lock
+++ b/account-comparison/Cargo.lock
@@ -1534,7 +1534,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1552,7 +1552,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -2355,8 +2355,9 @@ dependencies = [
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2383,8 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2433,8 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -2446,8 +2449,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2458,8 +2462,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-ff 0.5.0",
@@ -2475,8 +2480,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint 0.4.6",
@@ -2486,8 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2501,8 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2513,8 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2529,8 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2585,8 +2595,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254 0.5.0",
  "ark-serialize 0.5.0",
@@ -2606,8 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2635,8 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2649,8 +2662,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2670,8 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -7372,15 +7387,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/account-comparison/Cargo.toml
+++ b/account-comparison/Cargo.toml
@@ -4,14 +4,6 @@ members = [
 ]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/account-comparison/programs/account-comparison/Cargo.toml
+++ b/account-comparison/programs/account-comparison/Cargo.toml
@@ -19,11 +19,11 @@ idl-build = ["anchor-lang/idl-build"]
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
+light-hasher = "6.0.0"
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }

--- a/basic-operations/anchor/burn/Cargo.lock
+++ b/basic-operations/anchor/burn/Cargo.lock
@@ -1268,7 +1268,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1286,7 +1286,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -2005,8 +2005,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2033,8 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2083,8 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -2096,8 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2108,8 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -2125,8 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2136,8 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2151,8 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2163,8 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2179,8 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2223,8 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2244,8 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2274,8 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2288,8 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2309,8 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6335,15 +6350,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/basic-operations/anchor/burn/Cargo.toml
+++ b/basic-operations/anchor/burn/Cargo.toml
@@ -4,14 +4,6 @@ members = [
 ]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/basic-operations/anchor/burn/programs/burn/Cargo.toml
+++ b/basic-operations/anchor/burn/programs/burn/Cargo.toml
@@ -19,10 +19,10 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }

--- a/basic-operations/anchor/close/Cargo.lock
+++ b/basic-operations/anchor/close/Cargo.lock
@@ -1268,7 +1268,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1286,7 +1286,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -2005,8 +2005,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2033,8 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2083,8 +2085,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -2096,8 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2108,8 +2112,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -2125,8 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2136,8 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2151,8 +2158,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2163,8 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2179,8 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2223,8 +2233,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2244,8 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2274,8 +2286,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2288,8 +2301,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2309,8 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6335,15 +6350,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/basic-operations/anchor/close/Cargo.toml
+++ b/basic-operations/anchor/close/Cargo.toml
@@ -4,14 +4,6 @@ members = [
 ]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/basic-operations/anchor/close/programs/close/Cargo.toml
+++ b/basic-operations/anchor/close/programs/close/Cargo.toml
@@ -19,10 +19,10 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }

--- a/basic-operations/anchor/create/Cargo.lock
+++ b/basic-operations/anchor/create/Cargo.lock
@@ -1269,7 +1269,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1287,7 +1287,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -2006,8 +2006,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2034,8 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2084,8 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -2097,8 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2109,8 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -2126,8 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2137,8 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2152,8 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2164,8 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2180,8 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2224,8 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2245,8 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2275,8 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2289,8 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2310,8 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6336,15 +6351,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/basic-operations/anchor/create/Cargo.toml
+++ b/basic-operations/anchor/create/Cargo.toml
@@ -4,14 +4,6 @@ members = [
 ]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/basic-operations/anchor/create/programs/create/Cargo.toml
+++ b/basic-operations/anchor/create/programs/create/Cargo.toml
@@ -19,11 +19,11 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
+light-hasher = "6.0.0"
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }

--- a/basic-operations/anchor/reinit/Cargo.lock
+++ b/basic-operations/anchor/reinit/Cargo.lock
@@ -1252,7 +1252,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1270,7 +1270,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1989,8 +1989,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2017,8 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2067,8 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -2080,8 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2092,8 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -2109,8 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2120,8 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2135,8 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2147,8 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2163,8 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2207,8 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2228,8 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2258,8 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2272,8 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2293,8 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6335,15 +6350,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/basic-operations/anchor/reinit/Cargo.toml
+++ b/basic-operations/anchor/reinit/Cargo.toml
@@ -4,14 +4,6 @@ members = [
 ]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/basic-operations/anchor/reinit/programs/reinit/Cargo.toml
+++ b/basic-operations/anchor/reinit/programs/reinit/Cargo.toml
@@ -19,10 +19,10 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }

--- a/basic-operations/anchor/update/Cargo.lock
+++ b/basic-operations/anchor/update/Cargo.lock
@@ -1252,7 +1252,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1270,7 +1270,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -2028,8 +2028,9 @@ checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2056,8 +2057,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2106,8 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -2119,8 +2122,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2131,8 +2135,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -2148,8 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2159,8 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2174,8 +2181,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2186,8 +2194,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2202,8 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2246,8 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2267,8 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2297,8 +2309,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2311,8 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2332,8 +2346,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6496,15 +6511,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/basic-operations/anchor/update/Cargo.toml
+++ b/basic-operations/anchor/update/Cargo.toml
@@ -4,14 +4,6 @@ members = [
 ]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/basic-operations/anchor/update/programs/update/Cargo.toml
+++ b/basic-operations/anchor/update/programs/update/Cargo.toml
@@ -19,10 +19,10 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }

--- a/basic-operations/native/Cargo.lock
+++ b/basic-operations/native/Cargo.lock
@@ -1038,7 +1038,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1056,7 +1056,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1760,8 +1760,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -1788,8 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1838,8 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -1851,8 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -1863,8 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -1880,8 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -1891,8 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -1906,8 +1913,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -1918,8 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -1934,8 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -1978,8 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -1999,8 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "bincode",
  "borsh",
@@ -2027,8 +2039,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2041,8 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2060,8 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6100,19 +6115,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-macros"
-version = "2.2.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/basic-operations/native/Cargo.toml
+++ b/basic-operations/native/Cargo.toml
@@ -8,13 +8,6 @@ members = [
 ]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-macros = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/basic-operations/native/programs/burn/Cargo.toml
+++ b/basic-operations/native/programs/burn/Cargo.toml
@@ -19,9 +19,9 @@ name = "test"
 required-features = ["test-helpers"]
 
 [dependencies]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["keccak"] }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-macros = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-sdk = { version = "0.24.0", features = ["keccak"] }
+light-hasher = "6.0.0"
+light-macros = "3.0.0"
 solana-program = "4.0"
 borsh = "1.7"
 
@@ -29,13 +29,13 @@ borsh = "1.7"
 # which has no solana target). Keep them out of the on-chain (SBF) build so
 # `cargo test-sbf` compiles the program.
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", optional = true }
+light-client = { version = "0.24.0", optional = true }
 solana-keypair = { version = "3.1.2", optional = true }
 solana-instruction = { version = "3.4", optional = true }
 solana-signer = { version = "3.0", optional = true }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 tokio = "1.49.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"

--- a/basic-operations/native/programs/close/Cargo.toml
+++ b/basic-operations/native/programs/close/Cargo.toml
@@ -19,9 +19,9 @@ name = "test"
 required-features = ["test-helpers"]
 
 [dependencies]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["keccak"] }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-macros = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-sdk = { version = "0.24.0", features = ["keccak"] }
+light-hasher = "6.0.0"
+light-macros = "3.0.0"
 solana-program = "4.0"
 borsh = "1.7"
 
@@ -29,13 +29,13 @@ borsh = "1.7"
 # which has no solana target). Keep them out of the on-chain (SBF) build so
 # `cargo test-sbf` compiles the program.
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", optional = true }
+light-client = { version = "0.24.0", optional = true }
 solana-keypair = { version = "3.1.2", optional = true }
 solana-instruction = { version = "3.4", optional = true }
 solana-signer = { version = "3.0", optional = true }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 tokio = "1.49.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"

--- a/basic-operations/native/programs/create/Cargo.toml
+++ b/basic-operations/native/programs/create/Cargo.toml
@@ -15,18 +15,18 @@ test-helpers = ["dep:light-client", "dep:solana-keypair", "dep:solana-instructio
 default = []
 
 [dependencies]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["keccak"] }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-macros = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-sdk = { version = "0.24.0", features = ["keccak"] }
+light-hasher = "6.0.0"
+light-macros = "3.0.0"
 solana-program = "4.0"
 borsh = "1.7"
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", optional = true }
+light-client = { version = "0.24.0", optional = true }
 solana-keypair = { version = "3.1.2", optional = true }
 solana-instruction = { version = "3.4", optional = true }
 solana-signer = { version = "3.0", optional = true }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 tokio = "1.49.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"

--- a/basic-operations/native/programs/reinit/Cargo.toml
+++ b/basic-operations/native/programs/reinit/Cargo.toml
@@ -19,9 +19,9 @@ name = "test"
 required-features = ["test-helpers"]
 
 [dependencies]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["keccak"] }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-macros = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-sdk = { version = "0.24.0", features = ["keccak"] }
+light-hasher = "6.0.0"
+light-macros = "3.0.0"
 solana-program = "4.0"
 borsh = "1.7"
 
@@ -29,13 +29,13 @@ borsh = "1.7"
 # which has no solana target). Keep them out of the on-chain (SBF) build so
 # `cargo test-sbf` compiles the program.
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", optional = true }
+light-client = { version = "0.24.0", optional = true }
 solana-keypair = { version = "3.1.2", optional = true }
 solana-instruction = { version = "3.4", optional = true }
 solana-signer = { version = "3.0", optional = true }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 tokio = "1.49.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"

--- a/basic-operations/native/programs/update/Cargo.toml
+++ b/basic-operations/native/programs/update/Cargo.toml
@@ -19,9 +19,9 @@ name = "test"
 required-features = ["test-helpers"]
 
 [dependencies]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["keccak"] }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-macros = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-sdk = { version = "0.24.0", features = ["keccak"] }
+light-hasher = "6.0.0"
+light-macros = "3.0.0"
 solana-program = "4.0"
 borsh = "1.7"
 
@@ -29,13 +29,13 @@ borsh = "1.7"
 # which has no solana target). Keep them out of the on-chain (SBF) build so
 # `cargo test-sbf` compiles the program.
 [target.'cfg(not(target_os = "solana"))'.dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", optional = true }
+light-client = { version = "0.24.0", optional = true }
 solana-keypair = { version = "3.1.2", optional = true }
 solana-instruction = { version = "3.4", optional = true }
 solana-signer = { version = "3.0", optional = true }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 tokio = "1.49.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"

--- a/counter/anchor/Cargo.lock
+++ b/counter/anchor/Cargo.lock
@@ -1269,7 +1269,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1287,7 +1287,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -2006,8 +2006,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2034,8 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2084,8 +2086,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -2097,8 +2100,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2109,8 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -2126,8 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2137,8 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2152,8 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2164,8 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2180,8 +2189,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2224,8 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2245,8 +2256,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2275,8 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2289,8 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2310,8 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6336,15 +6351,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/counter/anchor/Cargo.toml
+++ b/counter/anchor/Cargo.toml
@@ -2,14 +2,6 @@
 members = ["programs/*"]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/counter/anchor/programs/counter/Cargo.toml
+++ b/counter/anchor/programs/counter/Cargo.toml
@@ -19,11 +19,11 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
+light-hasher = "6.0.0"
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }

--- a/counter/native/Cargo.lock
+++ b/counter/native/Cargo.lock
@@ -1057,7 +1057,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1075,7 +1075,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1779,8 +1779,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -1807,8 +1808,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1857,8 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -1870,8 +1873,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -1882,8 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -1899,8 +1904,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -1910,8 +1916,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -1925,8 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -1937,8 +1945,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -1953,8 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -1997,8 +2007,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2018,8 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "bincode",
  "borsh",
@@ -2046,8 +2058,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2060,8 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2079,8 +2093,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]

--- a/counter/native/Cargo.toml
+++ b/counter/native/Cargo.toml
@@ -19,14 +19,14 @@ test-sbf = []
 default = []
 
 [dependencies]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["keccak"] }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-sdk = { version = "0.24.0", features = ["keccak"] }
+light-hasher = "6.0.0"
 solana-program = "4.0"
-light-macros = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-macros = "3.0.0"
 borsh = "1.7"
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }
@@ -38,16 +38,6 @@ solana-signer = "3.0"
 five8_core = { version = "0.1.2", features = ["std"] }
 
 tokio = "1.49.0"
-
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher, light-client and light-macros to local paths
-# pulls their entire transitive light-* graph from the ~/dev/light/light-sdks
-# workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-macros = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
 
 [lints.rust.unexpected_cfgs]
 level = "allow"

--- a/create-and-update/Cargo.lock
+++ b/create-and-update/Cargo.lock
@@ -2061,8 +2061,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2089,8 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2139,8 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh 1.6.0",
  "light-bounded-vec",
@@ -2152,8 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh 1.6.0",
  "light-hasher",
@@ -2164,8 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -2181,8 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2192,8 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2207,8 +2214,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2219,8 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh 1.6.0",
  "bytemuck",
@@ -2235,8 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2279,8 +2289,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2300,8 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2330,8 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2344,8 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh 1.6.0",
@@ -2365,8 +2379,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]

--- a/create-and-update/Cargo.toml
+++ b/create-and-update/Cargo.toml
@@ -4,14 +4,6 @@ members = [
 ]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/create-and-update/programs/create-and-update/Cargo.toml
+++ b/create-and-update/programs/create-and-update/Cargo.toml
@@ -20,11 +20,11 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 [dependencies]
 anchor-lang = "1.0.2"
 borsh = "0.10.4"
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
+light-hasher = "6.0.0"
 
 [dev-dependencies]
-light-client = "0.23.0"
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }

--- a/read-only/Cargo.lock
+++ b/read-only/Cargo.lock
@@ -1158,7 +1158,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1176,7 +1176,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1869,8 +1869,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -1897,8 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1947,8 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -1960,8 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -1972,8 +1976,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -1989,8 +1994,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2000,8 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2015,8 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2027,8 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2043,8 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2087,8 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2108,8 +2119,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2137,8 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2151,8 +2164,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2172,8 +2186,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6007,15 +6022,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/read-only/Cargo.toml
+++ b/read-only/Cargo.toml
@@ -13,10 +13,10 @@ test-sbf = []
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }
@@ -28,14 +28,6 @@ solana-signer = "3.0"
 five8_core = { version = "0.1.2", features = ["std"] }
 
 tokio = "1.49.0"
-
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
 
 [profile.release]
 overflow-checks = true

--- a/zk/nullifier/Cargo.lock
+++ b/zk/nullifier/Cargo.lock
@@ -1252,7 +1252,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23f76610e969fa1784327ded240f1e28a3fd9520c9cec93b636fcf62dd37f772"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1270,7 +1270,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a0f1728185f277989ca573a402716ae0beaaea3f76a8ff87ef9dd8fb19436c5"
 dependencies = [
- "five8_core 0.1.2",
+ "five8_core 1.0.0",
 ]
 
 [[package]]
@@ -1989,8 +1989,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "light-account-checks"
-version = "0.8.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0291401f7d8557dbd5d2b35eb8c88cf406373f5ff7667b5751e0fa51e8f1257f"
 dependencies = [
  "solana-account-info",
  "solana-cpi",
@@ -2017,8 +2018,9 @@ dependencies = [
 
 [[package]]
 name = "light-client"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befd65b894eff8df2d8e50c6596153d2fb52813cac4c89dd210fd5aabf7336cf"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -2067,8 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "light-concurrent-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ac3848e3d368f4864fa43d1a736190ea1e6335a9e0c06ce8371872193c043d"
 dependencies = [
  "borsh",
  "light-bounded-vec",
@@ -2080,8 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "light-event"
-version = "0.23.1"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f10a0d6c3718b2fc8b54726f461e807284d06e0a57673c1368986a5d97eeb1"
 dependencies = [
  "borsh",
  "light-hasher",
@@ -2092,8 +2096,9 @@ dependencies = [
 
 [[package]]
 name = "light-hasher"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97e859b5551be970823d57f75e434f5e6255ec9adc7d2314a665f7f388314657"
 dependencies = [
  "ark-bn254",
  "ark-ff",
@@ -2109,8 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-array"
-version = "0.3.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd43549440e0102dc0b86b9406dc01335d88fc1a750a1749daec52ddff94e95"
 dependencies = [
  "light-hasher",
  "num-bigint",
@@ -2120,8 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "light-indexed-merkle-tree"
-version = "5.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936bdee0249aeda07401da793edd16b2345644adb23206eacb57611666702c8f"
 dependencies = [
  "light-bounded-vec",
  "light-concurrent-merkle-tree",
@@ -2135,8 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "light-macros"
-version = "2.2.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c7207c0e1e5f7c9a0f6224813fa9aaf1ae2b68a09c55a58056d2204a8d35e47"
 dependencies = [
  "bs58",
  "proc-macro2",
@@ -2147,8 +2155,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-metadata"
-version = "0.11.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a223b6f16d1fc84489a5ee7a6f1c1ebab61b3062cce587665cb5f1db04f5b3"
 dependencies = [
  "borsh",
  "bytemuck",
@@ -2163,8 +2172,9 @@ dependencies = [
 
 [[package]]
 name = "light-merkle-tree-reference"
-version = "4.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2afff6531c279de51bb76422e8cfbe65f38fa2db694879ef45679c6d75b83b"
 dependencies = [
  "light-hasher",
  "light-indexed-array",
@@ -2207,8 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "light-prover-client"
-version = "8.0.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27f307d972df5ce7e8b28161308e8ddd3c819425505e846fbba22fe4e792707e"
 dependencies = [
  "ark-bn254",
  "ark-serialize",
@@ -2228,8 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d03c8d729e9996b0d260704ad58b1e4ba5b1c6d80b99207f9dd53b4dbf37b67f"
 dependencies = [
  "anchor-lang",
  "bincode",
@@ -2258,8 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-macros"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ee0a698d9a1af1480950719efda5f8c4fcf268e48dad61159b257690a57853"
 dependencies = [
  "darling 0.21.3",
  "light-hasher",
@@ -2272,8 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "light-sdk-types"
-version = "0.23.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c0a2b970773d05cdeb19f51f549ac06a8aea0eea740375339934f6092d8b74"
 dependencies = [
  "anchor-lang",
  "borsh",
@@ -2293,8 +2307,9 @@ dependencies = [
 
 [[package]]
 name = "light-zero-copy"
-version = "0.6.0"
-source = "git+https://github.com/Lightprotocol/light-sdks?rev=12ab48bde9260b80c7d8b6d38b066be357c1acc2#12ab48bde9260b80c7d8b6d38b066be357c1acc2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2ff0625565b7d0b665fa3fc73a5c4fdb072b44792c872391673827b3edd4c4"
 dependencies = [
  "zerocopy",
 ]
@@ -6335,15 +6350,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "light-client"
-version = "0.23.0"
-
-[[patch.unused]]
-name = "light-hasher"
-version = "5.0.0"
-
-[[patch.unused]]
-name = "light-sdk"
-version = "0.23.0"

--- a/zk/nullifier/Cargo.toml
+++ b/zk/nullifier/Cargo.toml
@@ -2,14 +2,6 @@
 members = ["programs/nullifier"]
 resolver = "2"
 
-# Use the local light-protocol SDK checkout instead of the released crates.
-# Patching light-sdk, light-hasher and light-client to local paths pulls their
-# entire transitive light-* graph from the ~/dev/light/light-sdks workspace.
-[patch.crates-io]
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-hasher = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
-
 [profile.release]
 overflow-checks = true
 lto = "fat"

--- a/zk/nullifier/programs/nullifier/Cargo.toml
+++ b/zk/nullifier/programs/nullifier/Cargo.toml
@@ -14,10 +14,10 @@ idl-build = ["anchor-lang/idl-build", "light-sdk/idl-build"]
 
 [dependencies]
 anchor-lang = "1.0.2"
-light-sdk = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2", features = ["anchor", "cpi-context", "keccak"] }
+light-sdk = { version = "0.24.0", features = ["anchor", "cpi-context", "keccak"] }
 
 [dev-dependencies]
-light-client = { git = "https://github.com/Lightprotocol/light-sdks", rev = "12ab48bde9260b80c7d8b6d38b066be357c1acc2" }
+light-client = "0.24.0"
 solana-instruction = "3.4"
 solana-keypair = "3.1.2"
 solana-pubkey = { version = "4.2", features = ["curve25519", "sha2"] }


### PR DESCRIPTION
Replace the Lightprotocol/light-sdks git dependencies with the newly published crates.io releases across the examples that used them:

  light-sdk     0.24.0
  light-client  0.24.0
  light-hasher  6.0.0
  light-macros  3.0.0

Removes the now-redundant [patch.crates-io] redirects from the affected workspace roots and regenerates their Cargo.lock files. Features and optional flags are preserved. Examples that already pinned published versions (simple-claim, counter/pinocchio, zk/zk-id) are left untouched.

All affected workspaces pass cargo check --all-targets.